### PR TITLE
Add custom exception handler and update project structure

### DIFF
--- a/MontelaApi.API/Extensions/ConfigureExceptionHandlerExtension.cs
+++ b/MontelaApi.API/Extensions/ConfigureExceptionHandlerExtension.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using System.Net;
+using System.Net.Mime;
+using System.Text.Json;
+
+namespace MontelaApi.API.Extensions
+{
+    static public class ConfigureExceptionHandlerExtension
+    {
+        public static void ConfigureExceptionHandler(this WebApplication application, ILogger<Program> logger)
+        {
+            application.UseExceptionHandler(builder =>
+            {
+                builder.Run(async context =>
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                    context.Response.ContentType = MediaTypeNames.Application.Json;
+
+                    var contextFeature = context.Features.Get<IExceptionHandlerFeature>();
+                    if (contextFeature != null)
+                    {
+                        logger.LogError(contextFeature.Error.Message);
+
+                        await context.Response.WriteAsync(JsonSerializer.Serialize(new
+                        {
+                            StatusCode = context.Response.StatusCode,
+                            Message = contextFeature.Error.Message,
+                        }));
+                    }
+                });
+            });
+
+        }
+    }
+}

--- a/MontelaApi.API/MontelaApi.API.csproj
+++ b/MontelaApi.API/MontelaApi.API.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Middlewares\" />
     <Folder Include="wwwroot\" />
   </ItemGroup>
 

--- a/MontelaApi.API/Program.cs
+++ b/MontelaApi.API/Program.cs
@@ -16,6 +16,7 @@ using Serilog.Sinks.MSSqlServer;
 using System.Collections.ObjectModel;
 using System.Data;
 using System.Text;
+using MontelaApi.API.Extensions;
 namespace MontelaApi.API
 {
     public class Program
@@ -116,6 +117,8 @@ namespace MontelaApi.API
                     .WithTheme(ScalarTheme.Purple)
                     .WithDefaultHttpClient(ScalarTarget.JavaScript, ScalarClient.Axios);
             });
+
+            app.ConfigureExceptionHandler(app.Services.GetRequiredService<ILogger<Program>>());
             app.UseStaticFiles();
 
             app.UseCors();


### PR DESCRIPTION
Updated MontelaApi.API.csproj to include new folders for "Middlewares" and "wwwroot". Added using directive for MontelaApi.API.Extensions in Program.cs. Added call to app.ConfigureExceptionHandler in Program.cs to configure a custom exception handler using a logger. Added ConfigureExceptionHandlerExtension.cs to define an extension method for setting up a global exception handler that logs errors and returns a JSON response with status code and error message for internal server errors.