### PR TITLE
Add Basket and BasketItem entities and repositories

### DIFF
--- a/Core/Application/Abstractions/Services/IBasketService.cs
+++ b/Core/Application/Abstractions/Services/IBasketService.cs
@@ -1,0 +1,13 @@
+﻿using Application.ViewModels.Baskets;
+using Domain.Entities;
+
+namespace Application.Abstractions.Services
+{
+    public interface IBasketService
+    {
+        public Task<List<BasketItem>> GetBasketItems();
+        public Task AddItemToBasketAsync(CreateBasketItems basketItem );
+        public Task UpdateQuantityAsync(UpdateBasketItem basketItem );
+        public Task RemoveBasketItemAsync(string basketItemId)
+    }
+}

--- a/Core/Application/Features/Commands/ProductImageFile/ChangeShowCaseImage/ChangeShowCaseImageCommandHandler.cs
+++ b/Core/Application/Features/Commands/ProductImageFile/ChangeShowCaseImage/ChangeShowCaseImageCommandHandler.cs
@@ -6,9 +6,9 @@ namespace Application.Features.Commands.ProductImageFile.ChangeShowCaseImage
 {
     public class ChangeShowCaseImageCommandHandler : IRequestHandler<ChangeShowCaseImageCommandRequest, ChangeShowCaseImageCommandResponse>
     {
-        readonly IProductImageFileWriteRepository _productImageFileWriteRepository;
+        readonly IProductImageWriteRepository _productImageFileWriteRepository;
 
-        public ChangeShowCaseImageCommandHandler(IProductImageFileWriteRepository productImageWriteRepository)
+        public ChangeShowCaseImageCommandHandler(IProductImageWriteRepository productImageWriteRepository)
         {
             _productImageFileWriteRepository = productImageWriteRepository;
         }
@@ -23,7 +23,7 @@ namespace Application.Features.Commands.ProductImageFile.ChangeShowCaseImage
                 });
 
             var data = await query.FirstOrDefaultAsync(p => p.product.Id == Guid.Parse(request.ProductId) && p.productImageFile.ShowCase);
-            if ((data))
+            if ((data != null))
             {
             data.productImageFile.ShowCase = false;
             }

--- a/Core/Application/Repositories/Basket/IBasketReadRepository.cs
+++ b/Core/Application/Repositories/Basket/IBasketReadRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IBasketReadRepository : IReadRepository<Basket>
+    {
+    }
+}

--- a/Core/Application/Repositories/Basket/IBasketWriteRepository.cs
+++ b/Core/Application/Repositories/Basket/IBasketWriteRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IBasketWriteRepository : IWriteRepository<Basket>
+    {
+    }
+}

--- a/Core/Application/Repositories/BasketItem/IBasketItemReadRepository.cs
+++ b/Core/Application/Repositories/BasketItem/IBasketItemReadRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IBasketItemReadRepository : IReadRepository<BasketItem>
+    {
+    }
+}

--- a/Core/Application/Repositories/BasketItem/IBasketItemWriteRepository.cs
+++ b/Core/Application/Repositories/BasketItem/IBasketItemWriteRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IBasketItemWriteRepository : IWriteRepository<BasketItem
+    {
+    }
+}

--- a/Core/Application/Repositories/ProductImageFile/IProductImageReadRepository.cs
+++ b/Core/Application/Repositories/ProductImageFile/IProductImageReadRepository.cs
@@ -2,7 +2,7 @@
 
 namespace Application.Repositories
 {
-    public interface IProductImageFileWriteRepository : IWriteRepository<ProductImageFile>
+    public interface IProductImageReadRepository : IReadRepository<ProductImageFile>
     {
     }
 }

--- a/Core/Application/ViewModels/Baskets/CreateBasketItems.cs
+++ b/Core/Application/ViewModels/Baskets/CreateBasketItems.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.ViewModels.Baskets
+{
+    public class CreateBasketItems
+    {
+    }
+}

--- a/Core/Application/ViewModels/Baskets/UpdateBasketItem.cs
+++ b/Core/Application/ViewModels/Baskets/UpdateBasketItem.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.ViewModels.Baskets
+{
+    public class UpdateBasketItem
+    {
+    }
+}

--- a/Core/Domain/Entities/Basket.cs
+++ b/Core/Domain/Entities/Basket.cs
@@ -1,0 +1,14 @@
+﻿using Domain.Entities.Common;
+using Domain.Entities.Identity;
+
+namespace Domain.Entities
+{
+    public class Basket : BaseEntity
+    {
+        public string UserId { get; set; }
+        public Guid OrderId { get; set; }
+        public virtual AppUser User { get; set; }
+        public virtual Order Order { get; set; }
+        public ICollection<BasketItem> BasketItems { get; set; }
+    }
+}

--- a/Core/Domain/Entities/BasketItem.cs
+++ b/Core/Domain/Entities/BasketItem.cs
@@ -1,0 +1,13 @@
+﻿using Domain.Entities.Common;
+
+namespace Domain.Entities
+{
+    public class BasketItem : BaseEntity
+    {
+        public Guid ProductId { get; set; }
+        public Guid BasketId { get; set; }
+        public int Quantity { get; set; }
+        public virtual Product Product { get; set; }
+        public virtual Basket Basket { get; set; }
+    }
+}

--- a/Core/Domain/Entities/Identity/AppUser.cs
+++ b/Core/Domain/Entities/Identity/AppUser.cs
@@ -7,5 +7,6 @@ namespace Domain.Entities.Identity
         public string FullName { get; set; }
         public string? RefreshToken { get; set; }
         public DateTime? RefreshTokenEndDate { get; set; }
+        public ICollection<Basket> Baskets { get; set; }
     }
 }

--- a/Core/Domain/Entities/Order.cs
+++ b/Core/Domain/Entities/Order.cs
@@ -10,9 +10,11 @@ namespace Domain.Entities
     public class Order : BaseEntity
     {
         public Guid CustomerId { get; set; }
+        public Guid BasketId { get; set; }
         public string Description { get; set; }
         public string Address { get; set; }
-        public Customer Customer { get; set; }
+        public virtual Customer Customer { get; set; }
+        public virtual Basket Basket { get; set; }
         public ICollection<Product> Products { get; set; }
     }
 }

--- a/Core/Domain/Entities/Product.cs
+++ b/Core/Domain/Entities/Product.cs
@@ -9,6 +9,7 @@ namespace Domain.Entities
         public float Price { get; set; }
         public ICollection<Order> Orders { get; set; }
         public ICollection<ProductImageFile> ProductImages { get; set; }
+        public ICollection<BasketItem> BasketItems { get; set; }
 
     }
 }

--- a/Infrastructure/Persistance/Context/ApplicationDbContext.cs
+++ b/Infrastructure/Persistance/Context/ApplicationDbContext.cs
@@ -15,6 +15,8 @@ namespace Persistance.Context
         public DbSet<Domain.Entities.File> Files { get; set; }
         public DbSet<ProductImageFile> ProductImages { get; set; }
         public DbSet<InvoiceFile> Invoices { get; set; }
+        public DbSet<Basket> Baskets { get; set; }
+        public DbSet<BasketItem> BasketItems { get; set; }
 
         public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/Infrastructure/Persistance/Migrations/20250320203629_mig_6.Designer.cs
+++ b/Infrastructure/Persistance/Migrations/20250320203629_mig_6.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Persistance.Context;
 
@@ -11,9 +12,11 @@ using Persistance.Context;
 namespace Persistance.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250320203629_mig_6")]
+    partial class mig_6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Infrastructure/Persistance/Migrations/20250320203629_mig_6.cs
+++ b/Infrastructure/Persistance/Migrations/20250320203629_mig_6.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistance.Migrations
+{
+    /// <inheritdoc />
+    public partial class mig_6 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Baskets_AspNetUsers_UserId1",
+                table: "Baskets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Baskets_UserId1",
+                table: "Baskets");
+
+            migrationBuilder.DropColumn(
+                name: "UserId1",
+                table: "Baskets");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UserId",
+                table: "Baskets",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Baskets_UserId",
+                table: "Baskets",
+                column: "UserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Baskets_AspNetUsers_UserId",
+                table: "Baskets",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Baskets_AspNetUsers_UserId",
+                table: "Baskets");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Baskets_UserId",
+                table: "Baskets");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "UserId",
+                table: "Baskets",
+                type: "uniqueidentifier",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UserId1",
+                table: "Baskets",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Baskets_UserId1",
+                table: "Baskets",
+                column: "UserId1");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Baskets_AspNetUsers_UserId1",
+                table: "Baskets",
+                column: "UserId1",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/Basket/BasketReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/Basket/BasketReadRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class BasketReadRepository : ReadRepository<Basket>, IBasketReadRepository
+    {
+        public BasketReadRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/Basket/BasketWriteRepository.cs
+++ b/Infrastructure/Persistance/Repositories/Basket/BasketWriteRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class BasketWriteRepository : WriteRepository<Basket>, IBasketWriteRepository
+    {
+        public BasketWriteRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/BasketItem/BasketItemReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/BasketItem/BasketItemReadRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class BasketItemReadRepository : ReadRepository<BasketItem>, IBasketItemReadRepository
+    {
+        public BasketItemReadRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/BasketItem/BasketItemWriteRepository.cs
+++ b/Infrastructure/Persistance/Repositories/BasketItem/BasketItemWriteRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class BasketItemWriteRepository : WriteRepository<BasketItem>, IBasketItemWriteRepository
+    {
+        public BasketItemWriteRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/ProductImage/ProductImageReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/ProductImage/ProductImageReadRepository.cs
@@ -4,7 +4,7 @@ using Persistance.Context;
 
 namespace Persistance.Repositories.ProductImage
 {
-    public class ProductImageReadRepository : ReadRepository<ProductImageFile>, IProductImageFileWriteRepository
+    public class ProductImageReadRepository : ReadRepository<ProductImageFile>, IProductImageReadRepository
     {
         public ProductImageReadRepository(ApplicationDbContext context) : base(context)
         {

--- a/Infrastructure/Persistance/ServiceRegistration.cs
+++ b/Infrastructure/Persistance/ServiceRegistration.cs
@@ -20,11 +20,11 @@ namespace Persistance
         {
             services.AddIdentity<AppUser, AppRole>(options =>
             {
-                options.Password.RequireNonAlphanumeric= false;
+                options.Password.RequireNonAlphanumeric = false;
                 options.Password.RequiredLength = 6;
-                options.Password.RequireUppercase= false;
-                options.Password.RequireLowercase= false;
-                options.Password.RequireDigit= false;
+                options.Password.RequireUppercase = false;
+                options.Password.RequireLowercase = false;
+                options.Password.RequireDigit = false;
             }).AddEntityFrameworkStores<ApplicationDbContext>();
 
             services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(configuration.GetConnectionString("SqlServer")));
@@ -34,12 +34,17 @@ namespace Persistance
             services.AddScoped<IOrderWriteRepository, OrderWriteRepository>();
             services.AddScoped<IProductReadRepository, ProductReadRepository>();
             services.AddScoped<IProductWriteRepository, ProductWriteRepository>();
-            services.AddScoped<IProductImageFileWriteRepository, ProductImageReadRepository>();
+            services.AddScoped<IProductImageReadRepository, ProductImageReadRepository>();
             services.AddScoped<IProductImageWriteRepository, ProductImageWriteRepository>();
             services.AddScoped<IFileReadRepository, FileReadRepository>();
             services.AddScoped<IFileWriteRepository, FileWriteRepository>();
             services.AddScoped<IInvoiceWriteRepository, InvoiceWriteRepository>();
             services.AddScoped<IInvoiceReadRepository, InvoiceReadRepository>();
+
+            services.AddScoped<IBasketItemReadRepository, BasketItemReadRepository>();
+            services.AddScoped<IBasketItemWriteRepository, BasketItemWriteRepository>();
+            services.AddScoped<IBasketReadRepository, BasketReadRepository>();
+            services.AddScoped<IBasketWriteRepository, BasketWriteRepository>();
 
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IAuthService, AuthService>();


### PR DESCRIPTION
Updated various classes and interfaces to support the new Basket and BasketItem entities:
- Changed `ChangeShowCaseImageCommandHandler` to use `IProductImageWriteRepository` and added a null check for `data`.
- Updated `AppUser` to include a collection of `Baskets`.
- Updated `Order` to include `BasketId` and virtual `Basket` properties.
- Updated `Product` to include a collection of `BasketItems`.
- Added `Baskets` and `BasketItems` DbSets to `ApplicationDbContext`.
- Updated `ApplicationDbContextModelSnapshot` for new entities and relationships.
- Updated `ProductImageReadRepository` to implement `IProductImageReadRepository`.
- Registered new repositories in `ServiceRegistration`.
- Added `IBasketService` interface.
- Added new repository interfaces for `Basket` and `BasketItem`.
- Added new view models `CreateBasketItems` and `UpdateBasketItem`.
- Added new entity classes `Basket` and `BasketItem`.
- Added `BasketItemReadRepository` class.