### PR TITLE
Add password reset and verification features

### DIFF
--- a/Core/Application/Abstractions/Services/IAuthService.cs
+++ b/Core/Application/Abstractions/Services/IAuthService.cs
@@ -4,5 +4,7 @@ namespace Application.Abstractions.Services
 {
     public interface IAuthService : IExternalAuthentification, IInternalAuthentification
     {
+        Task ResetPasswordAsync(string email);
+        Task<bool > VerifyResetTokenAsync(string resetToken, string userId);
     }
 }

--- a/Core/Application/Abstractions/Services/IMailService.cs
+++ b/Core/Application/Abstractions/Services/IMailService.cs
@@ -4,6 +4,6 @@
     {
         Task SendMailAsync(string to, string subject, string body, bool isBodyHtml = true);
         Task SendMailAsync(List<string> to, string subject, string body, bool isBodyHtml = true);
-        Task SendPasswordResetMailAsync(string to, string userId, string resetToken);
+        Task SendResetPasswordMailAsync(string to, string userId, string resetToken);
     }
 }

--- a/Core/Application/Abstractions/Services/IUserService.cs
+++ b/Core/Application/Abstractions/Services/IUserService.cs
@@ -6,6 +6,7 @@ namespace Application.Abstractions.Services
     public interface IUserService
     {
         Task<CreateUserResponseDto> CreateAsync(CreateUserDto user);
-        Task UpdateRefreshToken(string refreshToken, AppUser user, DateTime accessTokenDate, int addOnAccessTokenTime);
+        Task UpdateRefreshTokenAsync(string refreshToken, AppUser user, DateTime accessTokenDate, int addOnAccessTokenTime);
+        Task UpdatePasswordAsync(string UserId, string resetToken, string newPassword);
     }
 }

--- a/Core/Application/Exceptions/User/PasswordChangeFailedException.cs
+++ b/Core/Application/Exceptions/User/PasswordChangeFailedException.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.Serialization;
+
+namespace Application.Exceptions.User
+{
+    public class PasswordChangeFailedException : Exception
+    {
+        public PasswordChangeFailedException() : base("Some thing went wrong, please try again later")
+        {
+        }
+
+        public PasswordChangeFailedException(string? message) : base(message)
+        {
+        }
+
+        public PasswordChangeFailedException(string? message, Exception? innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/Core/Application/Features/Commands/User/ResetPassword/ResetPasswordCommandHandler.cs
+++ b/Core/Application/Features/Commands/User/ResetPassword/ResetPasswordCommandHandler.cs
@@ -1,0 +1,21 @@
+﻿using Application.Abstractions.Services;
+using MediatR;
+
+namespace Application.Features.Commands.User.ResetPassword
+{
+    public class ResetPasswordCommandHandler : IRequestHandler<ResetPasswordCommandRequest, ResetPasswordCommandResponse>
+    {
+        readonly IAuthService _authService;
+
+        public ResetPasswordCommandHandler(IAuthService authService)
+        {
+            _authService = authService;
+        }
+
+        public async Task<ResetPasswordCommandResponse> Handle(ResetPasswordCommandRequest request, CancellationToken cancellationToken)
+        {
+            await _authService.ResetPasswordAsync(request.Email);
+            return new();
+        }
+    }
+}

--- a/Core/Application/Features/Commands/User/ResetPassword/ResetPasswordCommandRequest.cs
+++ b/Core/Application/Features/Commands/User/ResetPassword/ResetPasswordCommandRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace Application.Features.Commands.User.ResetPassword
+{
+    public class ResetPasswordCommandRequest : IRequest<ResetPasswordCommandResponse>
+    {
+        public string Email { get; set; }
+    }
+}

--- a/Core/Application/Features/Commands/User/ResetPassword/ResetPasswordCommandResponse.cs
+++ b/Core/Application/Features/Commands/User/ResetPassword/ResetPasswordCommandResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.Features.Commands.User.ResetPassword
+{
+    public class ResetPasswordCommandResponse
+    {
+    }
+}

--- a/Core/Application/Features/Commands/User/UpdatePassword/UpdatePasswordCommandHandler.cs
+++ b/Core/Application/Features/Commands/User/UpdatePassword/UpdatePasswordCommandHandler.cs
@@ -1,0 +1,25 @@
+﻿using Application.Abstractions.Services;
+using Application.Exceptions.User;
+using MediatR;
+
+namespace Application.Features.Commands.User.UpdatePassword
+{
+    public class UpdatePasswordCommandHandler : IRequestHandler<UpdatePasswordCommandRequest, UpdatePasswordCommandResponse>
+    {
+        readonly IUserService _userService;
+
+        public UpdatePasswordCommandHandler(IUserService userService)
+        {
+            _userService = userService;
+        }
+
+        public async Task<UpdatePasswordCommandResponse> Handle(UpdatePasswordCommandRequest request, CancellationToken cancellationToken)
+        {
+            if (!request.NewPassword.Equals(request.NewPasswordConfirm))
+                throw new PasswordChangeFailedException();
+
+            await _userService.UpdatePasswordAsync(request.UserId, request.ResetToken, request.NewPassword);
+            return new();
+        }
+    }
+}

--- a/Core/Application/Features/Commands/User/UpdatePassword/UpdatePasswordCommandRequest.cs
+++ b/Core/Application/Features/Commands/User/UpdatePassword/UpdatePasswordCommandRequest.cs
@@ -1,0 +1,12 @@
+﻿using MediatR;
+
+namespace Application.Features.Commands.User.UpdatePassword
+{
+    public class UpdatePasswordCommandRequest : IRequest<UpdatePasswordCommandResponse>
+    {
+        public string UserId { get; set; }
+        public string ResetToken { get; set; }
+        public string NewPassword { get; set; }
+        public string NewPasswordConfirm { get; set; }
+    }
+}

--- a/Core/Application/Features/Commands/User/UpdatePassword/UpdatePasswordCommandResponse.cs
+++ b/Core/Application/Features/Commands/User/UpdatePassword/UpdatePasswordCommandResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace Application.Features.Commands.User.UpdatePassword
+{
+    public class UpdatePasswordCommandResponse
+    {
+    }
+}

--- a/Core/Application/Features/Commands/User/VerifyResetToken/VerifyResetTokenCommandHandler.cs
+++ b/Core/Application/Features/Commands/User/VerifyResetToken/VerifyResetTokenCommandHandler.cs
@@ -1,0 +1,24 @@
+﻿using Application.Abstractions.Services;
+using MediatR;
+
+namespace Application.Features.Commands.User.VerifyResetToken
+{
+    public class VerifyResetTokenCommandHandler : IRequestHandler<VerifyResetTokenCommandRequest, VerifyResetTokenCommandResponse>
+    {
+        readonly IAuthService _authService;
+
+        public VerifyResetTokenCommandHandler(IAuthService authService)
+        {
+            _authService = authService;
+        }
+
+        public async Task<VerifyResetTokenCommandResponse> Handle(VerifyResetTokenCommandRequest request, CancellationToken cancellationToken)
+        {
+            bool state = await _authService.VerifyResetTokenAsync(request.ResetToken, request.UserId);
+            return new()
+            {
+                State = state,
+            };
+        }
+    }
+}

--- a/Core/Application/Features/Commands/User/VerifyResetToken/VerifyResetTokenCommandRequest.cs
+++ b/Core/Application/Features/Commands/User/VerifyResetToken/VerifyResetTokenCommandRequest.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace Application.Features.Commands.User.VerifyResetToken
+{
+    public class VerifyResetTokenCommandRequest : IRequest<VerifyResetTokenCommandResponse>
+    {
+        public string UserId { get; set; }
+        public string ResetToken { get; set; }
+    }
+}

--- a/Core/Application/Features/Commands/User/VerifyResetToken/VerifyResetTokenCommandResponse.cs
+++ b/Core/Application/Features/Commands/User/VerifyResetToken/VerifyResetTokenCommandResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace Application.Features.Commands.User.VerifyResetToken
+{
+    public class VerifyResetTokenCommandResponse
+    {
+        public bool State { get; set; }
+    }
+}

--- a/Core/Application/Helpers/CustomEncoders.cs
+++ b/Core/Application/Helpers/CustomEncoders.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using System.Text;
+
+namespace Application.Helpers
+{
+    public static class CustomEncoders
+    {
+        public static string UrlEncode(this string value)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(value);
+            return WebEncoders.Base64UrlEncode(bytes);
+        }
+
+        public static string UrlDecode(this string value)
+        {
+            byte[] bytes = WebEncoders.Base64UrlDecode(value);
+            return Encoding.UTF8.GetString(bytes);
+        }
+    }
+}

--- a/Infrastructure/Infrastructure/Services/MailServices/MailService.cs
+++ b/Infrastructure/Infrastructure/Services/MailServices/MailService.cs
@@ -39,9 +39,10 @@ namespace Infrastructure.Services.MailServices
             await smtp.SendMailAsync(mail);
         }
 
-        public async Task SendPasswordResetMailAsync(string to, string userId, string resetToken)
+        public async Task SendResetPasswordMailAsync(string to, string userId, string resetToken)
         {
-            string resetLink = $"Hi! <br> If you want reset password, yo have a link for reset password <br> <strong> <a target='blank' href='....../{userId}/{resetToken}'></a> Touch for new password </strong> <br><br><br> Montela";
+            string clientUrl = _configuration["ClientUrl"];
+            string resetLink = $"Hi! <br> If you want reset password, yo have a link for reset password <br> <strong> <a target='blank' href='{clientUrl}/update-password/{userId}/{resetToken}'></a> Touch for new password </strong> <br><br><br> Montela";
 
            await SendMailAsync(to, "Reset Password", resetLink);
         }

--- a/Infrastructure/Persistance/ServiceRegistration.cs
+++ b/Infrastructure/Persistance/ServiceRegistration.cs
@@ -2,6 +2,7 @@
 using Application.Abstractions.Services.Authentification;
 using Application.Repositories;
 using Domain.Entities.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +26,8 @@ namespace Persistance
                 options.Password.RequireUppercase = false;
                 options.Password.RequireLowercase = false;
                 options.Password.RequireDigit = false;
-            }).AddEntityFrameworkStores<ApplicationDbContext>();
+            }).AddEntityFrameworkStores<ApplicationDbContext>()
+            .AddDefaultTokenProviders();
 
             services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(configuration.GetConnectionString("SqlServer")));
             services.AddScoped<ICustomerReadRepository, CustomerReadRepository>();

--- a/Infrastructure/Persistance/Services/UserService.cs
+++ b/Infrastructure/Persistance/Services/UserService.cs
@@ -2,6 +2,7 @@
 using Application.DTOs.User;
 using Application.Exceptions.User;
 using Application.Features.Commands.User.CreateUser;
+using Application.Helpers;
 using Azure.Core;
 using Domain.Entities.Identity;
 using Microsoft.AspNetCore.Identity;
@@ -41,7 +42,21 @@ namespace Persistance.Services
             return response;
         }
 
-        public async Task UpdateRefreshToken(string refreshToken, AppUser user, DateTime accessTokenDate, int addOnAccessTokenTime)
+        public async Task UpdatePasswordAsync(string UserId, string resetToken, string newPassword)
+        {
+            AppUser? user = await _userManager.FindByIdAsync(UserId);
+            if (user is not null)
+            {
+                resetToken = resetToken.UrlDecode();
+                IdentityResult result = await _userManager.ResetPasswordAsync(user, resetToken, newPassword);
+                if (result.Succeeded)
+                    await _userManager.UpdateSecurityStampAsync(user);
+                else
+                    throw new PasswordChangeFailedException();
+            }
+        }
+
+        public async Task UpdateRefreshTokenAsync(string refreshToken, AppUser user, DateTime accessTokenDate, int addOnAccessTokenTime)
         {
             if (user is not null)
             {

--- a/MontelaApi.API/Controllers/AuthController.cs
+++ b/MontelaApi.API/Controllers/AuthController.cs
@@ -2,6 +2,8 @@
 using Application.Features.Commands.User.GoogleLogin;
 using Application.Features.Commands.User.LoginUser;
 using Application.Features.Commands.User.RefreshTokenLogin;
+using Application.Features.Commands.User.ResetPassword;
+using Application.Features.Commands.User.VerifyResetToken;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -43,6 +45,21 @@ namespace MontelaApi.API.Controllers
         public async Task<IActionResult> FacebookLogin(FacebookLoginCommandRequest facebookLoginCommandRequest)
         {
             FacebookLoginCommandResponse response = await _mediator.Send(facebookLoginCommandRequest);
+            return Ok(response);
+        }
+
+        [HttpPost("reset-password")]
+
+        public async Task<IActionResult> ResetPassword([FromBody]ResetPasswordCommandRequest request)
+        {
+            ResetPasswordCommandResponse response = await _mediator.Send(request);
+            return Ok(response);
+        }
+
+        [HttpPost("verify-resetToken")]
+        public async Task<IActionResult> VerifyResetToken([FromBody] VerifyResetTokenCommandRequest request)
+        {
+            VerifyResetTokenCommandResponse response = await _mediator.Send(request);
             return Ok(response);
         }
     }

--- a/MontelaApi.API/Controllers/UsersController.cs
+++ b/MontelaApi.API/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 ﻿using Application.Features.Commands.User.CreateUser;
+using Application.Features.Commands.User.UpdatePassword;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,6 +21,13 @@ namespace MontelaApi.API.Controllers
         {
             CreateUserCommandResponse response = await _mediator.Send(createUserCommandRequest);
             return Ok(response);
+        }
+
+        [HttpPost("update-password")]
+        public async Task<IActionResult> UpdatePassword([FromBody] UpdatePasswordCommandRequest request)
+        {
+            UpdatePasswordCommandResponse response = await _mediator.Send(request);
+            return Ok();
         }
     }
 }

--- a/MontelaApi.API/appsettings.json
+++ b/MontelaApi.API/appsettings.json
@@ -15,6 +15,7 @@
     "Google": ""
   },
   "BaseStorageUrl": "https://montela.blob.core.windows.net",
+  "ClientUrl" :  "http://localhost:4200"
   "JWTToken": {
     "Audience": "",
     "Issuer": "",


### PR DESCRIPTION
- Updated IAuthService with ResetPasswordAsync and VerifyResetTokenAsync methods.
- Renamed SendPasswordResetMailAsync to SendResetPasswordMailAsync in IMailService.
- Added UpdatePasswordAsync to IUserService and renamed UpdateRefreshToken to UpdateRefreshTokenAsync.
- Modified MailService to use ClientUrl for reset password links.
- Enhanced ServiceRegistration with default token providers for identity services.
- Updated AuthService and UserService to support new password reset functionalities.
- Added new endpoints in AuthController and UsersController for password operations.
- Introduced ClientUrl in appsettings.json for email links.
- Added PasswordChangeFailedException for handling password change errors.
- Created command handlers and request/response classes for reset password and token verification.
- Implemented CustomEncoders for URL encoding/decoding in the password reset process.