### PR TITLE
Add completed order management feature

### DIFF
--- a/Core/Application/Repositories/CompletedOrder/ICompletedOrderReadRepository.cs
+++ b/Core/Application/Repositories/CompletedOrder/ICompletedOrderReadRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface ICompletedOrderReadRepository : IReadRepository<CompletedOrder>
+    {
+    }
+}

--- a/Core/Application/Repositories/CompletedOrder/ICompletedOrderWriteRepository.cs
+++ b/Core/Application/Repositories/CompletedOrder/ICompletedOrderWriteRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface ICompletedOrderWriteRepository : IWriteRepository<CompletedOrder>
+    {
+    }
+}

--- a/Core/Domain/Entities/CompletedOrder.cs
+++ b/Core/Domain/Entities/CompletedOrder.cs
@@ -1,0 +1,10 @@
+﻿using Domain.Entities.Common;
+
+namespace Domain.Entities
+{
+    public class CompletedOrder : BaseEntity
+    {
+        public Guid OrderId { get; set; }
+        public virtual Order Order { get; set; }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/CompletedOrder/CompletedOrderReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/CompletedOrder/CompletedOrderReadRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class CompletedOrderReadRepository : ReadRepository<CompletedOrder>, ICompletedOrderReadRepository
+    {
+        public CompletedOrderReadRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/CompletedOrder/CompletedOrderWriteRepository.cs
+++ b/Infrastructure/Persistance/Repositories/CompletedOrder/CompletedOrderWriteRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class CompletedOrderWriteRepository : WriteRepository<CompletedOrder>, ICompletedOrderWriteRepository
+    {
+        public CompletedOrderWriteRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/ServiceRegistration.cs
+++ b/Infrastructure/Persistance/ServiceRegistration.cs
@@ -44,6 +44,8 @@ namespace Persistance
             services.AddScoped<IBasketItemWriteRepository, BasketItemWriteRepository>();
             services.AddScoped<IBasketReadRepository, BasketReadRepository>();
             services.AddScoped<IBasketWriteRepository, BasketWriteRepository>();
+            services.AddScoped<ICompletedOrderReadRepository, CompletedOrderReadRepository>();
+            services.AddScoped<ICompletedOrderWriteRepository, CompletedOrderWriteRepository>();
 
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IAuthService, AuthService>();


### PR DESCRIPTION
This commit introduces a new feature for managing completed orders in the application. It includes the registration of `ICompletedOrderReadRepository` and `ICompletedOrderWriteRepository` services in `ServiceRegistration.cs`. New interfaces for reading and writing completed orders have been created, along with the `CompletedOrder` entity class. Additionally, implementations for the read and write repositories have been added, enhancing the application's capability to handle completed order data.