### PR TITLE
Add new authorization system with endpoint definitions

### DIFF
--- a/Core/Application/Abstractions/Services/Configuration/IAuthorizeDefinitionService.cs
+++ b/Core/Application/Abstractions/Services/Configuration/IAuthorizeDefinitionService.cs
@@ -1,0 +1,9 @@
+﻿using Application.DTOs.Configuration;
+
+namespace Application.Abstractions.Services.Configuration
+{
+    public interface IAuthorizeDefinitionService
+    {
+        List<Menu> GetAuthorizeDefinitionEndpoints( Type type);
+    }
+}

--- a/Core/Application/Attributes/AuthorizeDefinitionAttribute.cs
+++ b/Core/Application/Attributes/AuthorizeDefinitionAttribute.cs
@@ -1,0 +1,11 @@
+﻿using Application.Enums;
+
+namespace Application.Attributes
+{
+    public class AuthorizeDefinitionAttribute : Attribute
+    {
+        public string Menu { get; set; }
+        public string Definition { get; set; }
+        public ActionType ActionType { get; set; }
+    }
+}

--- a/Core/Application/Constants/AuthorizeDefinitionConstants.cs
+++ b/Core/Application/Constants/AuthorizeDefinitionConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace Application.Constants
+{
+    public static class AuthorizeDefinitionConstants
+    {
+        public const string Baskets = "Baskets";
+        public const string Orders = "Orders";
+    }
+}

--- a/Core/Application/DTOs/Configuration/Action.cs
+++ b/Core/Application/DTOs/Configuration/Action.cs
@@ -1,0 +1,12 @@
+﻿using Application.Enums;
+
+namespace Application.DTOs.Configuration
+{
+    public class Action
+    {
+        public string ActionType { get; set; }
+        public string HttpType { get; set; }
+        public string Definition { get; set; }
+        public string Code { get; set; }
+    }
+}

--- a/Core/Application/DTOs/Configuration/Menu.cs
+++ b/Core/Application/DTOs/Configuration/Menu.cs
@@ -1,0 +1,8 @@
+﻿namespace Application.DTOs.Configuration
+{
+    public class Menu
+    {
+        public string Name { get; set; }
+        public List<Action> Actions { get; set; }
+    }
+}

--- a/Core/Application/Enums/ActionType.cs
+++ b/Core/Application/Enums/ActionType.cs
@@ -1,0 +1,10 @@
+﻿namespace Application.Enums
+{
+    public enum ActionType
+    {
+        Reading,
+        Writing,
+        Updating,
+        Deleting
+    }
+}

--- a/Infrastructure/Infrastructure/ServiceRegistration.cs
+++ b/Infrastructure/Infrastructure/ServiceRegistration.cs
@@ -1,8 +1,10 @@
 ﻿using Application.Abstractions;
 using Application.Abstractions.Services;
+using Application.Abstractions.Services.Configuration;
 using Application.Abstractions.Storage;
 using Infrastructure.Enums;
 using Infrastructure.Services;
+using Infrastructure.Services.Configuration;
 using Infrastructure.Services.MailServices;
 using Infrastructure.Services.Storage;
 using Infrastructure.Services.Storage.Azure;
@@ -18,6 +20,7 @@ namespace Infrastructure
             services.AddScoped<IStorageService, StorageService>();
             services.AddScoped<ITokenHandler, TokenHandler>();
             services.AddScoped<IMailService, MailService>();
+            services.AddScoped<IAuthorizeDefinitionService, AuthorizeDefinitionService>();
         }
         public static void AddStorage<T>(this IServiceCollection services) where T : Storage,  IStorage
         {

--- a/Infrastructure/Infrastructure/Services/Configuration/AuthorizeDefinitionService.cs
+++ b/Infrastructure/Infrastructure/Services/Configuration/AuthorizeDefinitionService.cs
@@ -1,0 +1,68 @@
+﻿using Application.Abstractions.Services.Configuration;
+using Application.Attributes;
+using Application.DTOs.Configuration;
+using Application.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using System.Reflection;
+
+namespace Infrastructure.Services.Configuration
+{
+    public class AuthorizeDefinitionService : IAuthorizeDefinitionService
+    {
+        public List<Menu> GetAuthorizeDefinitionEndpoint(Type type)
+        {
+            Assembly assembly = Assembly.GetAssembly(type);
+
+            List<Menu> menus = new();
+
+            var controllers = assembly.GetTypes().Where(t => t.IsAssignableTo(typeof(ControllerBase)));
+            if (controllers is not null)
+            {
+                foreach (var controller in controllers)
+                {
+                    var actions = controller.GetMethods().Where(m => m.IsDefined(typeof(AuthorizeDefinitionAttribute)));
+                    if (actions is not null)
+                    {
+                        foreach (var action in actions)
+                        {
+                            var attributes = action.GetCustomAttributes(true);
+                            if (attributes is not null)
+                            {
+                                Menu menu = new Menu();
+
+                                var authorizeDefinitionAttribute = attributes.FirstOrDefault(a => a.GetType() == typeof(AuthorizeDefinitionAttribute)) as AuthorizeDefinitionAttribute;
+                                if (!menus.Any(m => m.Name == authorizeDefinitionAttribute.Menu))
+                                {
+                                    menu.Name = authorizeDefinitionAttribute?.Menu;
+                                    menus.Add(menu);
+                                }
+                                else
+                                    menu = menus.FirstOrDefault(m => m.Name == authorizeDefinitionAttribute.Menu);
+
+                                Application.DTOs.Configuration.Action _action = new()
+                                {
+                                    ActionType =  Enum.GetName(typeof(ActionType), authorizeDefinitionAttribute.ActionType),
+                                    Definition = authorizeDefinitionAttribute.Definition,
+                                };
+
+                                var httpAttribute = attributes.FirstOrDefault(a => a.GetType().IsAssignableTo(typeof(HttpMethodAttribute))) as HttpMethodAttribute;
+                                if (httpAttribute is not null)
+                                    _action.HttpType = httpAttribute.HttpMethods.First();
+                                else
+                                    _action.HttpType = HttpMethods.Get;
+
+                                _action.Code = $"{_action.HttpType}.{_action.ActionType}.{_action.Definition.Replace(" ", "")}";
+
+                                menu.Actions.Add(_action);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return menus;
+        }
+    }
+}

--- a/MontelaApi.API/Controllers/ApplicationServicesController.cs
+++ b/MontelaApi.API/Controllers/ApplicationServicesController.cs
@@ -1,0 +1,25 @@
+﻿using Application.Abstractions.Services.Configuration;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MontelaApi.API.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ApplicationServicesController : ControllerBase
+    {
+        readonly IAuthorizeDefinitionService _authorizationDefinitionService;
+
+        public ApplicationServicesController(IAuthorizeDefinitionService authorizationDefinitionService)
+        {
+            _authorizationDefinitionService = authorizationDefinitionService;
+        }
+
+        [HttpGet]
+        public IActionResult GetAuthorizeDefinitionEndpoints()
+        {
+            var datas = _authorizationDefinitionService.GetAuthorizeDefinitionEndpoints(typeof(Program));
+
+            return Ok(datas);
+        }
+    }
+}

--- a/MontelaApi.API/Controllers/BasketsController.cs
+++ b/MontelaApi.API/Controllers/BasketsController.cs
@@ -1,4 +1,6 @@
-﻿using Application.Features.Commands.Basket.AddItemToBasket;
+﻿using Application.Attributes;
+using Application.Constants;
+using Application.Features.Commands.Basket.AddItemToBasket;
 using Application.Features.Commands.Basket.RemoveBasketItem;
 using Application.Features.Commands.Basket.UpdateBasketItemQuantity;
 using Application.Features.Queries.Basket.GetBasketItems;
@@ -21,6 +23,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpGet]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Baskets, ActionType = Application.Enums.ActionType.Reading, Definition ="Get Basket Items")]
         public async Task<IActionResult> GetBasketItems([FromQuery]GetBasketItemsQueryRequest request)
         {
             List<GetBasketItemsQueryResponse> response = await _mediator.Send(request);
@@ -28,6 +31,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpPost]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Baskets, ActionType = Application.Enums.ActionType.Writing, Definition = "Add Item to Basket")]
         public async Task<IActionResult> AddItemToBasket(AddItemToBasketCommandRequest request)
         {
             AddItemToBasketCommandResponse response = await _mediator.Send(request);
@@ -35,6 +39,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpPut]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Baskets, ActionType = Application.Enums.ActionType.Updating, Definition = "Update Quantity")]
         public async Task<IActionResult> UpdateQuantity(UpdateBasketItemQuantityCommandRequest request)
         {
             UpdateBasketItemQuantityCommandResponse response = await _mediator.Send(request);
@@ -42,6 +47,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpDelete("{BasketItemId}")]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Baskets, ActionType = Application.Enums.ActionType.Deleting, Definition = "Remove Basket Item")]
         public async Task<IActionResult> RemoveBasketItem([FromRoute]RemoveBasketItemCommandRequest request)
         {
             RemoveBasketItemCommandResponse response = await _mediator.Send(request);

--- a/MontelaApi.API/Controllers/OrdersController.cs
+++ b/MontelaApi.API/Controllers/OrdersController.cs
@@ -1,4 +1,6 @@
-﻿using Application.Features.Commands.CompleteOrder;
+﻿using Application.Attributes;
+using Application.Constants;
+using Application.Features.Commands.CompleteOrder;
 using Application.Features.Commands.Order.CreateOrder;
 using Application.Features.Queries.Order.GetAllOrders;
 using Application.Features.Queries.Order.GetOrderById;
@@ -22,6 +24,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpPost]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Orders, ActionType = Application.Enums.ActionType.Writing, Definition = "Create Order")]
         public async Task<IActionResult> CreateOrder(CreateOrderCommandRequest request)
         {
             CreateOrderCommandResponse response = await _mediator.Send(request);    
@@ -29,6 +32,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpGet]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Orders, ActionType = Application.Enums.ActionType.Reading, Definition = "Get All Orders")]
         public async Task<IActionResult> GetAllOrders([FromQuery]GetAllOrdersQueryRequest request)
         {
             GetAllOrdersQueryResponse response = await _mediator.Send(request);
@@ -36,6 +40,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpGet("{Id}")]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Orders, ActionType = Application.Enums.ActionType.Reading, Definition = "Get Order by Id")]
         public async Task<IActionResult> GetOrderById([FromRoute]GetOrderByIdQueryRequest request)
         {
             GetOrderByIdQueryResponse response = await _mediator.Send(request);
@@ -43,6 +48,7 @@ namespace MontelaApi.API.Controllers
         }
 
         [HttpGet("complete-order/{id}")]
+        [AuthorizeDefinition(Menu = AuthorizeDefinitionConstants.Orders, ActionType = Application.Enums.ActionType.Updating, Definition = "Complete Order")]
         public async Task<IActionResult> CompletedOrder([FromRoute]CompleteOrderCommandRequest request)
         {
             CompleteOrderCommandResponse response = await _mediator.Send(request);


### PR DESCRIPTION
This commit introduces an `IAuthorizeDefinitionService` interface and its implementation to manage authorization definitions for API endpoints. New attributes, such as `AuthorizeDefinitionAttribute`, are created to annotate controller actions with metadata, enhancing the structure of authorization.

An `ActionType` enum categorizes actions into Reading, Writing, Updating, and Deleting. A `Menu` class is added to organize actions by menu, and `AuthorizeDefinitionConstants` holds constant menu names for "Baskets" and "Orders".

The `ServiceRegistration.cs` file is updated to register the new service, while `BasketsController.cs` and `OrdersController.cs` are modified to use the new authorization attributes. A new `ApplicationServicesController.cs` is added to expose an endpoint for retrieving authorization definitions.

Overall, these changes significantly improve the application's authorization capabilities.