### PR TITLE
Add repository interfaces and implementations for Menu and Endpoint

### DIFF
--- a/Core/Application/Repositories/Endpoint/IEndpointReadRepository.cs
+++ b/Core/Application/Repositories/Endpoint/IEndpointReadRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IEndpointReadRepository : IReadRepository<Endpoint>
+    {
+    }
+}

--- a/Core/Application/Repositories/Endpoint/IEndpointWriteRepository.cs
+++ b/Core/Application/Repositories/Endpoint/IEndpointWriteRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IEndpointWriteRepository : IWriteRepository<Endpoint>
+    {
+    }
+}

--- a/Core/Application/Repositories/Menu/IMenuReadRepository.cs
+++ b/Core/Application/Repositories/Menu/IMenuReadRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IMenuReadRepository : IReadRepository<Menu>
+    {
+    }
+}

--- a/Core/Application/Repositories/Menu/IMenuWriteRepository.cs
+++ b/Core/Application/Repositories/Menu/IMenuWriteRepository.cs
@@ -1,0 +1,8 @@
+﻿using Domain.Entities;
+
+namespace Application.Repositories
+{
+    public interface IMenuWriteRepository : IWriteRepository<Menu>
+    {
+    }
+}

--- a/Infrastructure/Persistance/Repositories/Endpoint/EndpointReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/Endpoint/EndpointReadRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class EndpointReadRepository : ReadRepository<Endpoint>, IEndpointReadRepository
+    {
+        public EndpointReadRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/Endpoint/EndpointWriteRepository.cs
+++ b/Infrastructure/Persistance/Repositories/Endpoint/EndpointWriteRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class EndpointWriteRepository : WriteRepository<Endpoint>, IEndpointWriteRepository
+    {
+        public EndpointWriteRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/Menu/MenuReadRepository.cs
+++ b/Infrastructure/Persistance/Repositories/Menu/MenuReadRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class MenuReadRepository : ReadRepository<Menu>, IMenuReadRepository
+    {
+        public MenuReadRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/Infrastructure/Persistance/Repositories/Menu/MenuWriteRepository.cs
+++ b/Infrastructure/Persistance/Repositories/Menu/MenuWriteRepository.cs
@@ -1,0 +1,13 @@
+﻿using Application.Repositories;
+using Domain.Entities;
+using Persistance.Context;
+
+namespace Persistance.Repositories
+{
+    public class MenuWriteRepository : WriteRepository<Menu>, IMenuWriteRepository
+    {
+        public MenuWriteRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces new repository interfaces:
- IEndpointReadRepository
- IEndpointWriteRepository
- IMenuReadRepository
- IMenuWriteRepository

Concrete classes for these repositories are also created:
- EndpointReadRepository
- EndpointWriteRepository
- MenuReadRepository
- MenuWriteRepository

These classes extend generic read and write repositories and include constructors for ApplicationDbContext to support CRUD operations.