### PR TITLE
Add constructor to Endpoint and update authorization logic

### DIFF
--- a/Core/Domain/Entities/Endpoint.cs
+++ b/Core/Domain/Entities/Endpoint.cs
@@ -5,6 +5,10 @@ namespace Domain.Entities
 {
     public class Endpoint : BaseEntity
     {
+        public Endpoint()
+        {
+            Roles = new   HashSet<AppRole>();
+        }
         public string ActionType { get; set; }
         public string HttpType { get; set; }
         public string Definition { get; set; }

--- a/Infrastructure/Persistance/Services/AuthorizationEndpointService.cs
+++ b/Infrastructure/Persistance/Services/AuthorizationEndpointService.cs
@@ -35,12 +35,32 @@ namespace Persistance.Services
                     Name = menu
                 });
             }
+            await _menuWriteRepository.SaveAsync();
 
            Endpoint? endpoint = await _endpointReadRepository.Table.Include(e => e.Menu).FirstOrDefaultAsync(e => e.Code == endpointCode &&  e.Menu.Name == menu);
             if(endpoint is null)
             {
-                _authorizeDefinitionService.GetAuthorizeDefinitionEndpoints(type).FirstOrDefault(m => m.Name == menu);
+                var action = _authorizeDefinitionService.GetAuthorizeDefinitionEndpoints(type)?
+                    .FirstOrDefault(m => m.Name == menu)?
+                    .Actions.FirstOrDefault(e => e.Code == endpointCode);
+
+                endpoint = new()
+                {
+                    Code = endpointCode,
+                    ActionType = action.ActionType,
+                    HttpType = action.HttpType,
+                    Definition = action.Definition,
+                    Id = Guid.NewGuid(),
+                };
             }
+            await _endpointWriteRepository.AddAsync(endpoint);
+            await _endpointWriteRepository.SaveAsync();
+
+            foreach (var role in roles)
+                endpoint.Roles.Add(new()
+                {
+
+                });
         }
     }
 }


### PR DESCRIPTION
- Introduced a constructor in the Endpoint class to initialize the Roles property as a new HashSet<AppRole>.
- Modified the logic in AuthorizationEndpointService to create a new endpoint object based on the retrieved action from the authorization definition.
- Added properties to the new endpoint object, including Code, ActionType, HttpType, Definition, and Id.
- Ensured the new endpoint is added to the repository and saved.
- Implemented a loop to populate the Roles collection of the endpoint with new role objects.