### PR TITLE
Add IUserNotificationPreferenceService interface

### DIFF
--- a/Core/Application/Abstractions/Services/IUserNotificationPreferenceService.cs
+++ b/Core/Application/Abstractions/Services/IUserNotificationPreferenceService.cs
@@ -1,0 +1,15 @@
+﻿using Domain.Enums;
+
+namespace Application.Common.Interfaces
+{
+    public interface IUserNotificationPreferenceService
+    {
+        Task<IEnumerable<Guid>> GetActiveUsersWithNotificationTypeEnabledAsync(NotificationType type, CancellationToken cancellationToken = default);
+        Task<IEnumerable<Guid>> GetActiveUsersWithMotivationEnabledAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<Guid>> GetActiveUsersWithHealthRemindersEnabledAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<Guid>> GetActiveUsersWithMarketingEnabledAsync(CancellationToken cancellationToken = default);
+        Task<IEnumerable<Guid>> GetMarketTrendSubscribersAsync(CancellationToken cancellationToken = default);
+        Task<bool> IsUserOptedInForNotificationTypeAsync(Guid userId, NotificationType type, CancellationToken cancellationToken = default);
+        Task<TimeSpan?> GetUserOptimalNotificationTimeAsync(Guid userId, CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
Introduces the IUserNotificationPreferenceService interface in the Application.Common.Interfaces namespace. This interface includes asynchronous methods for managing user notification preferences, such as retrieving active users by notification type, checking user opt-in status, and determining optimal notification times.