### PR TITLE
Add ValidationBehavior for request validation

### DIFF
--- a/Core/Application/Behaviors/ValidationBehavior.cs
+++ b/Core/Application/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,35 @@
+﻿using FluentValidation;
+using MediatR;
+
+namespace Application.Behaviors
+{
+    public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+    {
+        readonly IEnumerable<IValidator<TRequest>> _validators;
+
+        public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+        {
+            _validators = validators;
+        }
+
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+        {
+            if (!_validators.Any()) return await next();
+
+            var context = new ValidationContext<TRequest>(request);
+
+            var validationResults = await Task.WhenAll(
+                _validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+            var failures = validationResults
+                .SelectMany(r => r.Errors)
+                .Where(f => f != null)
+                .ToList();
+
+            if (failures.Any())
+                throw new ValidationException(failures);
+
+            return await next();
+        }
+    }
+}


### PR DESCRIPTION
Introduces `ValidationBehavior<TRequest, TResponse>` in the `Application.Behaviors` namespace. This class implements `IPipelineBehavior<TRequest, TResponse>` to validate requests using FluentValidation. It processes a collection of validators and throws a `ValidationException` if validation fails, otherwise it proceeds to the next handler in the pipeline.